### PR TITLE
chore: kysely, d1 세팅

### DIFF
--- a/server/app/package.json
+++ b/server/app/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@hono/zod-validator": "^0.2.1",
     "hono": "^4.3.0",
+    "kysely": "^0.27.3",
+    "kysely-d1": "^0.3.0",
     "zod": "^3.22.4"
   }
 }

--- a/server/app/src/router/api/test/index.ts
+++ b/server/app/src/router/api/test/index.ts
@@ -24,7 +24,6 @@ export const creaetTestRouter = () => {
         .selectAll()
         .where("CustomerId", "=", 1)
         .executeTakeFirst();
-      console.log("result", result);
 
       return c.json({ result: "test success 1" }, 200);
     })

--- a/server/app/src/router/api/test/index.ts
+++ b/server/app/src/router/api/test/index.ts
@@ -1,10 +1,31 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { Kysely } from "kysely";
+import { D1Dialect } from "kysely-d1";
 import { z } from "zod";
 
+type Bindings = {
+  DEV_DB: D1Database;
+};
+
+type DataBase = {
+  Customers: { CustomerId: number; CompanyName: string; ContactName: string };
+};
+
 export const creaetTestRouter = () => {
-  return new Hono()
-    .get("/v1/hono-test-get", (c) => {
+  return new Hono<{ Bindings: Bindings }>()
+    .get("/v1/hono-test-get", async (c) => {
+      const db = new Kysely<DataBase>({
+        dialect: new D1Dialect({ database: c.env.DEV_DB }),
+      });
+
+      const result = await db
+        .selectFrom("Customers")
+        .selectAll()
+        .where("CustomerId", "=", 1)
+        .executeTakeFirst();
+      console.log("result", result);
+
       return c.json({ result: "test success 1" }, 200);
     })
     .post(

--- a/server/app/wrangler.toml
+++ b/server/app/wrangler.toml
@@ -33,10 +33,10 @@ compatibility_flags = ["nodejs_compat"]
 # Bind a D1 database. D1 is Cloudflare’s native serverless SQL database.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#d1-databases
 # [[d1_databases]]
-# binding = "DEV_DB"
-# database_name = "dev-db"
-# database_id = "7176cb96-6b89-4b7c-99b3-3957efaaa737"
-# preview_database_id = "dev-db"
+binding = "DEV_DB"
+database_name = "dev-db"
+database_id = "7176cb96-6b89-4b7c-99b3-3957efaaa737"
+preview_database_id = "dev-db"
 
 # Bind a dispatch namespace. Use Workers for Platforms to deploy serverless functions programmatically on behalf of your customers.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#dispatch-namespace-bindings-workers-for-platforms

--- a/server/app/wrangler.toml
+++ b/server/app/wrangler.toml
@@ -33,9 +33,10 @@ compatibility_flags = ["nodejs_compat"]
 # Bind a D1 database. D1 is Cloudflare’s native serverless SQL database.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#d1-databases
 # [[d1_databases]]
-# binding = "MY_DB"
-# database_name = "my-database"
-# database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+# binding = "DEV_DB"
+# database_name = "dev-db"
+# database_id = "7176cb96-6b89-4b7c-99b3-3957efaaa737"
+# preview_database_id = "dev-db"
 
 # Bind a dispatch namespace. Use Workers for Platforms to deploy serverless functions programmatically on behalf of your customers.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#dispatch-namespace-bindings-workers-for-platforms

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,6 +1307,8 @@ __metadata:
     "@repo/eslint-config": "npm:*"
     "@repo/typescript-config": "npm:*"
     hono: "npm:^4.3.0"
+    kysely: "npm:^0.27.3"
+    kysely-d1: "npm:^0.3.0"
     typescript: "npm:^5.0.4"
     vitest: "npm:1.3.0"
     wrangler: "npm:^3.51.2"
@@ -5421,6 +5423,22 @@ __metadata:
   version: 1.2.4
   resolution: "ky@npm:1.2.4"
   checksum: 10c0/d0df4c1685655a8731ff8c0a014d6050485a0e52fb1d6cc107235f8c3879b6569fc497d6d15cd6b8977db7102253a0e201899f2c24408e51a4c207179c601121
+  languageName: node
+  linkType: hard
+
+"kysely-d1@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "kysely-d1@npm:0.3.0"
+  peerDependencies:
+    kysely: "*"
+  checksum: 10c0/a91f3771e00007906462606d12e4df920d5c4823c1c973747bda02f67d742605f2ee2678ead5ae675cf2d8f2789cd3152a5a67ef2b8a7da6ea7377319593b711
+  languageName: node
+  linkType: hard
+
+"kysely@npm:^0.27.3":
+  version: 0.27.3
+  resolution: "kysely@npm:0.27.3"
+  checksum: 10c0/73c730404090744e7b89b1ca6870f1256fc9c0f2d5bcf739238ba293eaed4991d8228f5618e8e27e0f63681e0f3583b8e712919687e815956270ac319786a866
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 작업내용
- kysely 세팅
- d1 세팅
  - 내용은 [노션](https://www.notion.so/tekiterpersonal/cloudflare-d1-kv-2de9d4432d3148989c877036a4349c87?pvs=4)에 정리했어요
  - [대시보드](https://dash.cloudflare.com/cd9a073b4ade3e8b7176ab13db2b1c62/workers/d1/databases/7176cb96-6b89-4b7c-99b3-3957efaaa737) 에서 확인할 수 있어요.

## 고민거리
- local에서 d1 db가 create가 안되네요. 사진 첨부합니다. local에서 dev db 어떻게 보여줄지 모르겠네요. 현재 local / preview / production의 구분과 사용법에 대한 이해가 부족합니다.
<img width="987" alt="Untitled" src="https://github.com/CyGitWorld/git-cy/assets/24906022/3e1c9e56-2424-402d-a90f-b6721e3e8338">


## 스크린샷
`curl "http://localhost:8787/api/test/v1/hono-test-get"`
<img width="574" alt="image" src="https://github.com/CyGitWorld/git-cy/assets/24906022/c5abb2a0-3786-496e-84e9-3c16334bdff3">
